### PR TITLE
fix: text area input supports autocorrect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ serde = "1.0.192"
 serde_derive = "1.0.192"
 serde_json = "1.0.108"
 wasm-bindgen = "0.2.88"
-web-sys = {version = "0.3.65", features = ["Window", "Storage"]}
+web-sys = {version = "0.3.65", features = ["Window", "Storage", "Event", "EventTarget"]}
 yew = {version = "0.21.0", features = ["csr"]}
 yew-export-button = {git = "https://github.com/Terkwood/yew-export-button", tag = "v3.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Terkwood <38859656+Terkwood@users.noreply.github.com>"]
 description = "mood tracking web application"
 edition = "2021"
 name = "equanimity"
-version = "1.2.5-a"
+version = "1.2.5-b"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ serde = "1.0.192"
 serde_derive = "1.0.192"
 serde_json = "1.0.108"
 wasm-bindgen = "0.2.88"
-web-sys = {version = "0.3.65", features = ["Window", "Storage", "Event", "EventTarget"]}
+web-sys = {version = "0.3.65", features = ["Window", "Storage", "Event", "EventTarget","HtmlTextAreaElement"]}
 yew = {version = "0.21.0", features = ["csr"]}
 yew-export-button = {git = "https://github.com/Terkwood/yew-export-button", tag = "v3.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Terkwood <38859656+Terkwood@users.noreply.github.com>"]
 description = "mood tracking web application"
 edition = "2021"
 name = "equanimity"
-version = "1.2.4"
+version = "1.2.5-a"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -99,6 +99,7 @@ impl Component for History {
                     HistoryTopView::MoodButtons => HistoryTopView::WaitingForText,
                     _ => HistoryTopView::MoodButtons,
                 };
+                self.show_history = !self.show_history;
                 true
             }
             HistoryMsg::ShowLogs => {

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -1,6 +1,8 @@
 use super::StorageState;
 use crate::*;
+use web_sys::HtmlTextAreaElement;
 use yew::html::onchange;
+use js_sys::{JsString, Object};
 
 pub struct History {
     text_area: String,
@@ -204,7 +206,14 @@ impl History {
                                 rows=6
                                 value={self.text_area.clone()}
                                 onfocus={ctx.link().callback(|_| HistoryMsg::FocusInput)}
-                                onchange={ctx.link().callback(|e: onchange::Event| HistoryMsg::TextAreaUpdated(e.target().map(|t|t.value_of()).map(|o|o.to_string()).map(|jsstr|jsstr.into()).unwrap_or_default()))}
+                                onchange={ctx.link().
+                                    callback(|e: onchange::Event| 
+                                        HistoryMsg::TextAreaUpdated(e
+                                            .target()
+                                            .map(|t|t.value_of())
+                                            .map(|o|o.dyn_into::<HtmlTextAreaElement>())
+                                            .map(|text_area_elem|  text_area_elem.unwrap().value())
+                                            .unwrap_or_default()))}
                                 placeholder="Greetings.">
                             </textarea>
                         </div>

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -105,10 +105,6 @@ impl Component for History {
                 ctx.props().show_logs.emit(());
                 false
             }
-            // HistoryMsg::ShowHistory => {
-            //     self.show_history = true;
-            //     true
-            // }
             HistoryMsg::FocusInput => {
                 self.show_history = false;
                 self.top_view = HistoryTopView::FocusedOnText;
@@ -205,14 +201,7 @@ impl History {
                                 rows=6
                                 value={self.text_area.clone()}
                                 onfocus={ctx.link().callback(|_| HistoryMsg::FocusInput)}
-                                onchange={ctx.link().
-                                    callback(|e: onchange::Event|
-                                        HistoryMsg::TextAreaUpdated(e
-                                            .target()
-                                            .map(|t|t.value_of())
-                                            .map(|o|o.dyn_into::<HtmlTextAreaElement>())
-                                            .map(|text_area_elem|  text_area_elem.unwrap().value())
-                                            .unwrap_or_default()))}
+                                onchange={on_change_callback(ctx)}
                                 placeholder="Greetings.">
                             </textarea>
                         </div>
@@ -245,4 +234,16 @@ fn text_entry_button_class(top_view: &HistoryTopView) -> &'static str {
         HistoryTopView::FocusedOnText => TEXT_ENTRY_BUTTON_FOCUSED,
         _ => TEXT_ENTRY_BUTTON_DEFAULT,
     }
+}
+
+fn on_change_callback(ctx: &yew::Context<History>) -> Callback<Event> {
+    ctx.link().callback(|e: onchange::Event| {
+        HistoryMsg::TextAreaUpdated(
+            e.target()
+                .map(|t| t.value_of())
+                .map(|o| o.dyn_into::<HtmlTextAreaElement>())
+                .map(|text_area_elem| text_area_elem.unwrap().value())
+                .unwrap_or_default(),
+        )
+    })
 }

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -1,7 +1,6 @@
-use yew::html::onchange;
-
 use super::StorageState;
 use crate::*;
+use yew::html::onchange;
 
 pub struct History {
     text_area: String,
@@ -105,10 +104,10 @@ impl Component for History {
                 ctx.props().show_logs.emit(());
                 false
             }
-            HistoryMsg::ShowHistory => {
-                self.show_history = true;
-                true
-            }
+            // HistoryMsg::ShowHistory => {
+            //     self.show_history = true;
+            //     true
+            // }
             HistoryMsg::FocusInput => {
                 self.show_history = false;
                 self.top_view = HistoryTopView::FocusedOnText;
@@ -205,7 +204,7 @@ impl History {
                                 rows=6
                                 value={self.text_area.clone()}
                                 onfocus={ctx.link().callback(|_| HistoryMsg::FocusInput)}
-                                onchange={ctx.link().callback(|e: onchange::Event| HistoryMsg::TextAreaUpdated(e.target().map(textarea::Element::value).unwrap_o+r("".to_string()))}
+                                onchange={ctx.link().callback(|e: onchange::Event| HistoryMsg::TextAreaUpdated(e.target().map(|t|t.value_of()).map(|o|o.to_string()).map(|jsstr|jsstr.into()).unwrap_or_default()))}
                                 placeholder="Greetings.">
                             </textarea>
                         </div>

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -1,3 +1,5 @@
+use yew::html::onchange;
+
 use super::StorageState;
 use crate::*;
 
@@ -21,7 +23,6 @@ pub enum HistoryMsg {
     SubmitNotes,
     ShowLogs,
     ToggleTopView,
-    ShowHistory,
     FocusInput,
 }
 
@@ -204,10 +205,7 @@ impl History {
                                 rows=6
                                 value={self.text_area.clone()}
                                 onfocus={ctx.link().callback(|_| HistoryMsg::FocusInput)}
-                                onchange={ctx.link().callback(|_| HistoryMsg::ShowHistory)}
-                                oninput={ctx.link().callback(|e: InputEvent |
-                                        HistoryMsg::TextAreaUpdated(e.data().unwrap_or_default())
-                                    )}
+                                onchange={ctx.link().callback(|e: onchange::Event| HistoryMsg::TextAreaUpdated(e.target().map(textarea::Element::value).unwrap_o+r("".to_string()))}
                                 placeholder="Greetings.">
                             </textarea>
                         </div>

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -206,7 +206,7 @@ impl History {
                                 value={self.text_area.clone()}
                                 onfocus={ctx.link().callback(|_| HistoryMsg::FocusInput)}
                                 onchange={ctx.link().
-                                    callback(|e: onchange::Event| 
+                                    callback(|e: onchange::Event|
                                         HistoryMsg::TextAreaUpdated(e
                                             .target()
                                             .map(|t|t.value_of())

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -2,7 +2,6 @@ use super::StorageState;
 use crate::*;
 use web_sys::HtmlTextAreaElement;
 use yew::html::onchange;
-use js_sys::{JsString, Object};
 
 pub struct History {
     text_area: String,


### PR DESCRIPTION
- [x] allow autocorrect & backspace in mobile browsers
- [x] make sure Exit button doesn't hide moods 